### PR TITLE
Fixes bug described in issue #44 by adding header removal functionali…

### DIFF
--- a/Jelly-browser/app/src/main/java/org/lineageos/jelly/webview/WebViewExt.kt
+++ b/Jelly-browser/app/src/main/java/org/lineageos/jelly/webview/WebViewExt.kt
@@ -24,8 +24,6 @@ import android.util.Log
 import android.view.View
 import android.webkit.WebView
 import android.widget.ProgressBar
-import androidx.preference.PreferenceManager
-import org.lineageos.jelly.R
 import org.lineageos.jelly.ui.UrlBarController
 import org.lineageos.jelly.utils.PrefsUtils
 import org.lineageos.jelly.utils.UrlUtils


### PR DESCRIPTION
Fixes bug by adding header removal functionality to setup() and calling setup() every time URL is loaded. It was initially only called when web view is initiated. This might have been an intentional bug in order to slightly decrease load time, but difference is not noticeable.